### PR TITLE
Make the range operators section more clear

### DIFF
--- a/apiary/cda-body.apib
+++ b/apiary/cda-body.apib
@@ -433,7 +433,7 @@ Let's find all non-archived entries.
 
   + Attributes (Empty Array)
 
-## Number Ranges [/spaces/{space_id}/entries?access_token={access_token}&content_type={content_type}&{attribute}%5Blte%5D={value}]
+## Ranges [/spaces/{space_id}/entries?access_token={access_token}&content_type={content_type}&{attribute}%5Blte%5D={value}]
 
 Four range operators are available:
 
@@ -442,7 +442,7 @@ Four range operators are available:
 - `gt`: Greater than
 - `gte`: Greater than or equal to
 
-Those operators can be applied to Date, Integer and Number Fields.
+Those operators can be applied to Date and Number Fields.
 
 + Parameters
     + space_id (required, string, `cfexampleapi`) ... Alphanumeric `id` of the Space to retrieve.
@@ -458,24 +458,6 @@ Let's find all cats which have 3 or less lives left.
 + Response 200 (application/vnd.contentful.delivery.v1+json)
 
   + Attributes (Empty Array)
-
-## Date Ranges [/spaces/{space_id}/entries?access_token={access_token}&content_type={content_type}&{attribute}%5Bgte%5D={value}]
-
-Four range operators are available:
-
-- `lt`: Less than
-- `lte`: Less than or equal to
-- `gt`: Greater than
-- `gte`: Greater than or equal to
-
-Those operators can be applied to Date, Integer and Number Fields.
-
-+ Parameters
-    + space_id (required, string, `cfexampleapi`) ... Alphanumeric `id` of the Space to retrieve.
-    + access_token (required, string, `b4c0n73n7fu1`) ... A *production* Content Delivery API Key.
-    + content_type (required, string, `cat`) ... Alphanumeric `id` of the Content Type to retrieve.
-    + attribute (required, string, `sys.updatedAt`) ... The attribute to match.
-    + value (required, `2013-01-01T00:00:00Z`) ... The value to match.
 
 ### Query Entries [GET]
 

--- a/apiary/cda-body.apib
+++ b/apiary/cda-body.apib
@@ -448,25 +448,10 @@ Those operators can be applied to Date and Number Fields.
     + space_id (required, string, `cfexampleapi`) ... Alphanumeric `id` of the Space to retrieve.
     + access_token (required, string, `b4c0n73n7fu1`) ... A *production* Content Delivery API Key.
     + content_type (required, string, `cat`) ... Alphanumeric `id` of the Content Type to retrieve.
-    + attribute (required, string, `fields.lives`) ... The attribute to match.
-    + value (required, `3`) ... The value to match.
+    + attribute (required, string, `sys.updatedAt`) ... The attribute to match.
+    + value (required, `2013-01-01T00:00:00Z`) ... The value to match.
 
-### Query Entries (Number range) [GET]
-
-Let's find all cats which have 3 or less lives left.
-
-+ Response 200 (application/vnd.contentful.delivery.v1+json)
-
-  + Attributes (Empty Array)
-
-+ Parameters
-    + space_id (required, string, `cfexampleapi`) ... Alphanumeric `id` of the Space to retrieve.
-    + access_token (required, string, `b4c0n73n7fu1`) ... A *production* Content Delivery API Key.
-    + content_type (required, string, `cat`) ... Alphanumeric `id` of the Content Type to retrieve.
-    + attribute (required, string, `fields.lives`) ... The attribute to match.
-    + value (required, `3`) ... The value to match.
-
-### Query Entries (Date range) [GET]
+### Query Entries [GET]
 
 Let's look for Entries that've been updated since midnight of January 1st 2013.
 

--- a/apiary/cda-body.apib
+++ b/apiary/cda-body.apib
@@ -451,7 +451,7 @@ Those operators can be applied to Date and Number Fields.
     + attribute (required, string, `fields.lives`) ... The attribute to match.
     + value (required, `3`) ... The value to match.
 
-### Query Entries [GET]
+### Query Entries (Number range) [GET]
 
 Let's find all cats which have 3 or less lives left.
 
@@ -459,7 +459,14 @@ Let's find all cats which have 3 or less lives left.
 
   + Attributes (Empty Array)
 
-### Query Entries [GET]
++ Parameters
+    + space_id (required, string, `cfexampleapi`) ... Alphanumeric `id` of the Space to retrieve.
+    + access_token (required, string, `b4c0n73n7fu1`) ... A *production* Content Delivery API Key.
+    + content_type (required, string, `cat`) ... Alphanumeric `id` of the Content Type to retrieve.
+    + attribute (required, string, `fields.lives`) ... The attribute to match.
+    + value (required, `3`) ... The value to match.
+
+### Query Entries (Date range) [GET]
 
 Let's look for Entries that've been updated since midnight of January 1st 2013.
 


### PR DESCRIPTION
## Summary

Simplify and clarify the documentation about the ranges operators

## Details

From my point of view there are some issues with the current sections about ranges:

- They are identical but have different titles: `Number Ranges` and `Date Ranges`.
- Inside them they refer to types other than the one mentioned in their title. For example inside the `Numbers Range` we say that the operators can also be applied to Dates.
- We say that the operators can be applied to `Integer` and `Number` fields but our current UI only lets you choose `Number` fields (even though you can select `Integer` or `Decimal` in the config dialog).

So I renamed the section to just `Ranges` and removed the `Integer` type.
