### PR TITLE
[Changed] Add delay to tests

### DIFF
--- a/apiary/Makefile
+++ b/apiary/Makefile
@@ -70,9 +70,10 @@ publish: test
 	$(APIARY) publish --api-name=$(IMAGES_APIARY_NAME) --path=$(IMAGES_BLUEPRINT)
 
 test: $(CDA_BLUEPRINT) $(CPA_BLUEPRINT) $(CMA_BLUEPRINT) $(IMAGES_BLUEPRINT)
-	$(DREDD) $(CPA_BLUEPRINT) $(CPA_HOST)
-	$(DREDD) $(CDA_BLUEPRINT) $(CDA_HOST)
+	$(DREDD) $(CPA_BLUEPRINT) $(CPA_HOST) --hookfiles=./test-hooks.js
+	$(DREDD) $(CDA_BLUEPRINT) $(CDA_HOST) --hookfiles=./test-hooks.js
 	$(DREDD) $(CMA_BLUEPRINT) $(CMA_HOST) \
+		--hookfiles=./test-hooks.js \
 		-h "Authorization: Bearer $(CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN)" \
 		-m GET #-m PUT -m POST #-m DELETE
 	#$(DREDD) $(IMAGES_BLUEPRINT) $(IMAGES_HOST)

--- a/apiary/test-hooks.js
+++ b/apiary/test-hooks.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var hooks = require('hooks');
+var delay = 1000/6.0;
+
+hooks.afterEach(function (transaction, done) {
+  setTimeout(done, delay);
+});


### PR DESCRIPTION
In order to fix the RateLimitExceeded error, this test adds an
artificial delay to the tests.