### PR TITLE
Lint generated blueprints for warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js: 5.1
 ruby: 2.2.3
 
 before_install:
+  - sudo apt-get install jq
   - make -C apiary install
 
 script:

--- a/apiary/Makefile
+++ b/apiary/Makefile
@@ -58,6 +58,9 @@ $(CPA_BLUEPRINT): outdir cpa.apib
 #	apiary fetch --api-name=$(CMA_APIARY_NAME) >$(CMA_BLUEPRINT)
 
 prepare: $(CDA_BLUEPRINT) $(CPA_BLUEPRINT) $(CMA_BLUEPRINT) $(IMAGES_BLUEPRINT)
+	for blueprint in $^; do \
+		./lint.sh $$blueprint || exit 1; \
+	done
 
 preview: check_apiary_token prepare
 	$(APIARY) preview --path=$(CDA_BLUEPRINT)

--- a/apiary/_partials/sync-resources.apib
+++ b/apiary/_partials/sync-resources.apib
@@ -65,7 +65,7 @@ If for some reason a client loses the `nextSyncUrl`, the client should delete it
 + Parameters
     + space_id (required, string, `cfexampleapi`) ... Alphanumeric `id` of the Space to retrieve.
     + access_token (required, string, `b4c0n73n7fu1`) ... :[token description](tokentype)
-    + sync_token (required, string, `w5ZGw6JFwqZmVcKsE8Kow4grw45QdybCnV_Cg8OASMKpwo1UY8K8bsKFwqJrw7DDhcKnM2RDOVbDt1E-wo7CnDjChMKKGsK1wrzCrBzCqMOpZAwOOcOvCcOAwqHDv0XCiMKaOcOxZA8BJUzDr8K-wo1lNx7DnHE`) ... An opaque token which is used to identify your previous sync.
+    + `sync_token`: `w5ZGw6JFwqZmVcKsE8Kow4grw45QdybCnV_Cg8OASMKpwo1UY8K8bsKFwqJrw7DDhcKnM2RDOVbDt1E-wo7CnDjChMKKGsK1wrzCrBzCqMOpZAwOOcOvCcOAwqHDv0XCiMKaOcOxZA8BJUzDr8K-wo1lNx7DnHE` (required) ... An opaque token which is used to identify your previous sync. ... An opaque token which is used to identify your previous sync.
 
 ### Query entries [GET]
 

--- a/apiary/lint.sh
+++ b/apiary/lint.sh
@@ -24,6 +24,7 @@ then
 	exit 1
 fi
 
+TMPDIR="${TMPDIR:-/tmp}"
 TMPFILE2=`mktemp $TMPDIR/tmp.XXXXXX`
 
 curl -s -X POST --data-binary @"$BLUEPRINT" 'https://api.apiblueprint.org/parser' \

--- a/apiary/lint.sh
+++ b/apiary/lint.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+BLUEPRINT=$1
+
+if [ -z "$BLUEPRINT" ]; then
+	echo "Usage: $0 blueprint-file" >&2
+	exit 1
+fi
+
+which jq >/dev/null 2>&1
+if [ $? -ne 0 ]
+then
+	echo 'Please install `jq` to lint blueprints.' >&2
+	exit 1
+fi
+
+echo "Linting $BLUEPRINT..."
+
+# Sanity check for hercule errors, because that does not set its exit status correctly :/
+grep -q '^:' "$BLUEPRINT"
+if [ $? -eq 0 ]
+then
+	echo 'Blueprint contains unresolved partials, check hercule output for errors.' >&2
+	exit 1
+fi
+
+TMPFILE2=`mktemp $TMPDIR/tmp.XXXXXX`
+
+curl -s -X POST --data-binary @"$BLUEPRINT" 'https://api.apiblueprint.org/parser' \
+	--header 'Content-Type: text/vnd.apiblueprint' \
+	--header 'Accept: application/vnd.refract.parse-result+json' >"$TMPFILE2"
+
+# We do not want to fail the build if the API is unreachable
+if [ $? -ne 0 ]
+then
+	echo 'Failed to lint via API blueprint API, skip linting...' >&2
+	exit 0
+fi
+
+ERROR="`cat "$TMPFILE2"|jq '.error.message'`"
+
+if [ "$ERROR" == "null" ]; then
+
+EXPRESSION='.content[] | select(.meta.classes[0] == "warning")'
+WARNINGS=`cat "$TMPFILE2"|jq -e "$EXPRESSION | .content"`
+echo "$WARNINGS"
+[[ "$WARNINGS" == "" ]]
+EXIT_CODE=$?
+
+else
+
+echo "$ERROR"
+exit 1
+
+fi
+
+rm -f "$TMPFILE2"
+
+exit $EXIT_CODE


### PR DESCRIPTION
It is easy to miss warnings in the `dredd` output, so we should explicitly make sure to check for them.