### PR TITLE
Set up pages for embedding Apiary in main website

### DIFF
--- a/apiary/blueprint-header.apib
+++ b/apiary/blueprint-header.apib
@@ -3,7 +3,12 @@
 You are now looking at the API references. Visit [Contentful developer center](https://www.contentful.com/developers/docs/) for more documentation and developer tools.
 
 See also references to other Contentful APIs:
-* [Content delivery API](http://docs.contentfulcda.apiary.io)
-* [Content management API](http://docs.contentfulcma.apiary.io)
-* [Content preview API](http://docs.contentpreviewapi.apiary.io)
-* [Images API](http://docs.contentfulimagesapi.apiary.io)
+* [Content Delivery API][cda-reference]
+* [Content Management API][cma-reference]
+* [Content Preview API][cpa-reference]
+* [Images API][images-reference]
+
+[cda-reference]:https://www.contentful.com/developers/docs/references/content-delivery-api
+[cma-reference]:https://www.contentful.com/developers/docs/references/content-management-api
+[cpa-reference]:https://www.contentful.com/developers/docs/references/content-preview-api
+[images-reference]: https://www.contentful.com/developers/docs/references/images-api

--- a/apiary/cda-header.apib
+++ b/apiary/cda-header.apib
@@ -1,7 +1,7 @@
 FORMAT: 1A
 HOST: https://cdn.contentful.com
 
-# Contentful Delivery API
+# Content Delivery API
 
 The Contentful Delivery API is a _fast_ read-only API for retrieving your content from Contentful. Content is delivered as JSON data; images, videos and other media is delivered as files.
 

--- a/apiary/cpa-header.apib
+++ b/apiary/cpa-header.apib
@@ -1,6 +1,6 @@
 FORMAT: 1A
 HOST: https://preview.contentful.com
 
-# Contentful Preview API
+# Content Preview API
 
 In addition to the Delivery API for published content, there is also a Preview API for previewing unpublished content as though it were published. It maintains the same behaviour and parameters as the Content Delivery API, but delivers the latest draft for entries and assets.

--- a/apiary/images-header.apib
+++ b/apiary/images-header.apib
@@ -1,9 +1,9 @@
 FORMAT: 1A
 HOST: https://images.contentful.com
 
-# Contentful Images API
+# Images API
 
-This documents the use of Contentful's images API, which allows the retrieval and manipulation of image files referenced from [Assets](http://docs.contentfulcda.apiary.io/#reference/assets).
+Contentful's Images API allows the retrieval and manipulation of image files referenced from [Assets](http://docs.contentfulcda.apiary.io/#reference/assets).
 
 The JSON for an Asset on Contentful looks like this:
 
@@ -26,4 +26,4 @@ The JSON for an Asset on Contentful looks like this:
   }
 ```
 
-This documentation deals with what parameters can be added to the URL specified in the `file.URL` field to manipulate and convert images.
+This documentation deals with what parameters can be added to the URL specified in the `file.url` field to manipulate and convert images.

--- a/docs/references/content-delivery-api.md
+++ b/docs/references/content-delivery-api.md
@@ -1,0 +1,4 @@
+---
+layout: api_reference
+page: :docsContentfulCda
+---

--- a/docs/references/content-management-api.md
+++ b/docs/references/content-management-api.md
@@ -1,0 +1,4 @@
+---
+layout: api_reference
+page: :docsContentfulCma
+---

--- a/docs/references/content-preview-api.md
+++ b/docs/references/content-preview-api.md
@@ -1,0 +1,4 @@
+---
+layout: api_reference
+page: :docsContentPreviewApi
+---

--- a/docs/references/images-api.md
+++ b/docs/references/images-api.md
@@ -1,0 +1,5 @@
+---
+layout: api_reference
+page: :docsContentfulImagesApi
+---
+


### PR DESCRIPTION
These empty markdown files are used by the static site generator for www.contentful.com to embed API docs from Apiary inline.