### PR TITLE
Add warning about content type and middlewares

### DIFF
--- a/apiary/cma-body.apib
+++ b/apiary/cma-body.apib
@@ -727,6 +727,10 @@ For example, when an Entry has been published:
 X-Contentful-Topic: ContentManagement.Entry.publish
 ```
 
+You should also take into account the Content-Type header. While the content we send in the request body is still JSON, we use the Content-Type header as a versioning mechanism for our API with the value `application/vnd.contentful.management.v1+json`.
+
+This is something you should take into account if you use some sort of middleware or autoparser for the request body.
+
 ### Body of Webhook HTTP Request
 
 The request body is the published Resource's body or deletion thereof.

--- a/apiary/cma-body.apib
+++ b/apiary/cma-body.apib
@@ -727,9 +727,7 @@ For example, when an Entry has been published:
 X-Contentful-Topic: ContentManagement.Entry.publish
 ```
 
-You should also take into account the Content-Type header. While the content we send in the request body is still JSON, we use the Content-Type header as a versioning mechanism for our API with the value `application/vnd.contentful.management.v1+json`.
-
-This is something you should take into account if you use some sort of middleware or autoparser for the request body.
+Your webhook receiver should also take into account the `Content-Type` header, which will have the value `application/vnd.contentful.management.v1+json`. Many web frameworks (such as Express.js) and their middleware components only automatically parse a request body if the content-type header is `application/json`, and thus require additional configuration to parse request bodies with a different content-type header.
 
 ### Body of Webhook HTTP Request
 


### PR DESCRIPTION
We had a user slightly confused about this as he was just throwing the
request at a JSON parser that somehow ignored it due to an unknown
content type.