### PR TITLE
Change sync content type filtering parameter

### DIFF
--- a/apiary/_partials/sync-resources.apib
+++ b/apiary/_partials/sync-resources.apib
@@ -41,14 +41,14 @@ Syncing with `initial=true` should only be done once for the initial sync when a
 
   + Attributes (Empty Array)
 
-## Initial synchronisation of Entries of a specific Content Type [/spaces/{space_id}/sync?access_token={access_token}&initial=true&type=Entry&content_type={content_type_id}]
+## Initial synchronisation of Entries of a specific Content Type [/spaces/{space_id}/sync?access_token={access_token}&initial=true&type=Entry&content_type={content_type}]
 
 For Entries, you can also specify a `content_type` parameter. When specifying `content_type` you must specify type as `Entry` (meaning that there will be no deletions). The `type` and `content_type` parameter can only be specified at the initial sync along with the `initial` parameter. Any subsequent syncs will only include the types you have specified. If you want to sync Entries by Content Type you should separately subscribe to a `Deletion` or `DeletedEntry` sync to get notified when Entries are deleted.
 
 + Parameters
     + space_id (required, string, `cfexampleapi`) ... Alphanumeric `id` of the Space to retrieve.
     + access_token (required, string, `b4c0n73n7fu1`) ... :[token description](tokentype)
-    + content_type_id (required, string, `cat`) ... Alphanumeric `id` of the Content Type to retrieve.
+    + content_type (required, string, `cat`) ... Alphanumeric `id` of the Content Type to retrieve.
 
 ### Query Entries [GET]
 


### PR DESCRIPTION
The parameter was listed as `content_type_id` and not `content_type` although the URL used the correct form.