### PR TITLE
Update widget list and add descriptions

### DIFF
--- a/apiary/_partials/cma/editing-interface.apib
+++ b/apiary/_partials/cma/editing-interface.apib
@@ -41,34 +41,93 @@ The Editing Interface would look like this:
 
 Please note that there are specific sets of applicable Widgets per Content Type field type:
 
-| Widget ID               | Applicable field types                 | Description               | Possible settings                                                                                                    |
-|-------------------------|----------------------------------------|---------------------------|----------------------------------------------------------------------------------------------------------------------|
-| assetLinkEditor         | Asset                                  |                           |                                                                                                                      |
-| assetGalleryEditor      | Asset (Array)                          |                           |                                                                                                                      |
-| assetLinksEditor        | Asset (Array)                          |                           |                                                                                                                      |
-| boolean                 | Boolean                                |                           | trueLabel (default: "Yes") - True condition custom label falseLabel (default: "No") - False condition custom label   |
-| datePicker              | Date                                   |                           | format (Default: timeZ, values: [dateonly, time, timeZ]) - Format ampm (Default: '24', values: [12, 24]) - Time Mode |
-| entryCardEditor         | Entry                                  |                           |                                                                                                                      |
-| entryCardsEditor        | Entry (Array)                          |                           |                                                                                                                      |
-| entryLinkEditor         | Entry                                  |                           |                                                                                                                      |
-| entryLinksEditor        | Entry (Array)                          |                           |                                                                                                                      |
-| fileEditor              | File                                   |                           |                                                                                                                      |
-| numberEditor            | Integer, Number                        |                           |                                                                                                                      |
-| rating                  | Integer, Number                        |                           | stars (default: 5, range: 1-20) - Number of stars                                                                    |
-| locationEditor          | Location                               |                           |                                                                                                                      |
-| objectEditor            | Object                                 |                           |                                                                                                                      |
-| urlEditor               | Symbol                                 |                           |                                                                                                                      |
-| slugEditor              | Symbol                                 |                           |                                                                                                                      |
-| ooyalaEditor            | Symbol                                 |                           |                                                                                                                      |
-| ooyalaMultiAssetEditor  | Symbol (Array)                         |                           |                                                                                                                      |
-| kalturaEditor           | Symbol                                 |                           |                                                                                                                      |
-| kalturaMultiVideoEditor | Symbol (Array)                         |                           |                                                                                                                      |
-| listInput               | Symbol (Array)                         |                           |                                                                                                                      |
-| multipleLine            | Text                                   |                           |                                                                                                                      |
-| markdown                | Text                                   |                           |                                                                                                                      |
-| singleLine              | Text, Symbol                           | A simple text input field |                                                                                                                      |
-| dropdown                | Text, Symbol, Integer, Number, Boolean |                           |                                                                                                                      |
-| radio                   | Text, Symbol, Integer, Number          |                           |                                                                                                                      |
+| Widget ID               | Applicable field types        | Description               |
+|-------------------------|-------------------------------|---------------------------|
+| assetLinkEditor         | Asset                         | Search and attach an asset. |
+| assetLinksEditor        | Asset (Array)                 | Search, attach, and reorder, multiple assets. |
+| assetGalleryEditor      | Asset (Array)                 | Search and attach multiple assets and preview them. |
+| boolean                 | Boolean                       | Radio buttons with customizable labels. |
+| datePicker              | Date                          | Select date, time, and timezon. |
+| entryLinkEditor         | Entry                         | Search and attach another entry.
+| entryLinksEditor        | Entry (Array)                 | Search and attach multiple entries. |
+| entryCardEditor         | Entry                         | Search, attach, and preview another entry. |
+| entryCardsEditor        | Entry (Array)                 | Search, attach, and preview multiple entries. |
+| numberEditor            | Integer, Number               | A simple input for numbers. |
+| rating                  | Integer, Number               | Uses stars to select a number. |
+| locationEditor          | Location                      | A map to select or find coordinates from an address. |
+| objectEditor            | Object                        | A code editor for JSON |
+| urlEditor               | Symbol                        | A text input that also shows a preview of the given URL. |
+| slugEditor              | Symbol                        | Automatically generates a slug and validates its uniqueness across entries. |
+| ooyalaEditor            | Symbol                        | Search and select a video hosted by [Ooyala][] |
+| kalturaEditor           | Symbol                        | Search and select a video hosted by [Kaltura][] |
+| kalturaMultiVideoEditor | Symbol (Array)                | Search and select multiple videos hosted by [Kaltura][] |
+| listInput               | Symbol (Array)                | Text input the splits values on `,`. |
+| multipleLine            | Text                          | A simple `<textarea>` input |
+| markdown                | Text                          | A full fleged [markdown editor][] |
+| singleLine              | Text, Symbol                  | A simple text input field |
+| dropdown                | Text, Symbol, Integer, Number | A `<input type="select">` element. It uses the values from an `in` validation on the content type field as options. |
+| radio                   | Text, Symbol, Integer, Number | A group of radio buttons. One for each value from the `in` validation on the content type field |
+
+[Kaltura]: https://www.contentful.com/ecosystem/kaltura/
+[Ooyala]: https://www.contentful.com/ecosystem/ooyala/
+[markdown editor]: https://www.contentful.com/r/knowledgebase/markdown/
+
+__Settings__
+
+A control may have custom settings that are passed to the widget to change its behavior or presentation.
+
+The control entry for a field of type `Boolean`, for example, could look like this.
+```json
+{
+  "fieldId": "isFeatured",
+  "widgetId": "boolean",
+  "settings": {
+    "helpText": "Should the post be featured on the homepage?",
+    "trueLable": "absolutely",
+    "falseLable": "rather not",
+  }
+}
+```
+
+If present, the `settings` object of a control must be an object. All widgets
+accept the `helpText` setting and use it to render additional information with
+the widget. Other settings are widget specific.
+
+<table>
+<thead>
+  <tr>
+    <th>Widget ID</th>
+    <th>Property Name</th>
+    <th>Description</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td rowspan="2">boolean</td>
+    <td><code>trueLabel</code></td>
+    <td>Shows this text next to the radio button that sets this value to `true`. Defaults to “Yes”.</td>
+  </tr>
+  <tr>
+    <td><code>falseLabel</code></td>
+    <td>Shows this text next to the radio button that sets this value to `false`. Defaults to “No”.</td>
+  </tr>
+  <tr>
+    <td>rating</td>
+    <td><code>stars</code></td>
+    <td>Number of stars to select from. Defaults to 5.</td>
+  </tr>
+  <tr>
+    <td rowspan="2">datePicker</td>
+    <td><code>format</code></td>
+    <td>One of “dateonly”, “time”, “timeZ” (default). Specifies whether to show the clock and/or timezone inputs.</td>
+  </tr>
+  <tr>
+    <td><code>ampm</code></td>
+    <td>Specifies which type of clock to use. Must be one of the stringss “12” or “24” (default).</td>
+  </tr>
+</tbody>
+</table>
+
 
 ## Editing Interface [/spaces/{space_id}/content_types/{content_type_id}/editor_interfaces/{editor_interface_id}]
 

--- a/apiary/_partials/cma/editing-interface.apib
+++ b/apiary/_partials/cma/editing-interface.apib
@@ -43,9 +43,9 @@ Please note that there are specific sets of applicable Widgets per Content Type 
 
 | Widget ID               | Applicable field types        | Description               |
 |-------------------------|-------------------------------|---------------------------|
-| assetLinkEditor         | Asset                         | Search and attach an asset. |
-| assetLinksEditor        | Asset (Array)                 | Search, attach, and reorder, multiple assets. |
-| assetGalleryEditor      | Asset (Array)                 | Search and attach multiple assets and preview them. |
+| assetLinkEditor         | Asset                         | Search, attach, and preview an asset. |
+| assetLinksEditor        | Asset (Array)                 | Search, attach, reorder, and preview multiple assets. |
+| assetGalleryEditor      | Asset (Array)                 | Search, attach, reorder, and preview multiple assets in a gallery layout |
 | boolean                 | Boolean                       | Radio buttons with customizable labels. |
 | datePicker              | Date                          | Select date, time, and timezon. |
 | entryLinkEditor         | Entry                         | Search and attach another entry.
@@ -61,7 +61,7 @@ Please note that there are specific sets of applicable Widgets per Content Type 
 | ooyalaEditor            | Symbol                        | Search and select a video hosted by [Ooyala][] |
 | kalturaEditor           | Symbol                        | Search and select a video hosted by [Kaltura][] |
 | kalturaMultiVideoEditor | Symbol (Array)                | Search and select multiple videos hosted by [Kaltura][] |
-| listInput               | Symbol (Array)                | Text input the splits values on `,`. |
+| listInput               | Symbol (Array)                | Text input that splits values on `,` and stores them as an array. |
 | multipleLine            | Text                          | A simple `<textarea>` input |
 | markdown                | Text                          | A full fleged [markdown editor][] |
 | singleLine              | Text, Symbol                  | A simple text input field |
@@ -83,8 +83,8 @@ The control entry for a field of type `Boolean`, for example, could look like th
   "widgetId": "boolean",
   "settings": {
     "helpText": "Should the post be featured on the homepage?",
-    "trueLable": "absolutely",
-    "falseLable": "rather not",
+    "trueLabel": "absolutely",
+    "falseLabel": "rather not",
   }
 }
 ```


### PR DESCRIPTION
* Added description to all widgets.
* Removed the Multi Ooyala widget since it is not supported anymore
* Removed the “Boolean” field type for dropdown widgets since it is not supported anymore.
* Removed the “fileEditor” widget since it is only supported in the Asset Editor.
* Added separate section for control settings.