### PR TITLE
Prevent the leaking of the Authorization header in TravisCI logs.

### DIFF
--- a/apiary/Makefile
+++ b/apiary/Makefile
@@ -76,9 +76,10 @@ publish_docs:
 test: check_cma_token prepare
 	$(DREDD) $(CPA_BLUEPRINT) $(CPA_HOST) --hookfiles=./test-hooks.js
 	$(DREDD) $(CDA_BLUEPRINT) $(CDA_HOST) --hookfiles=./test-hooks.js
-	$(DREDD) $(CMA_BLUEPRINT) $(CMA_HOST) \
+	@$(DREDD) $(CMA_BLUEPRINT) $(CMA_HOST) \
 		--hookfiles=./test-hooks.js \
 		-h "Authorization: Bearer $(CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN)" \
+		--private-header Authorization \
 		-m GET #-m PUT -m POST #-m DELETE
 	#$(DREDD) $(IMAGES_BLUEPRINT) $(IMAGES_HOST) --hookfiles=./test-hooks.js
 

--- a/apiary/package.json
+++ b/apiary/package.json
@@ -6,7 +6,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "dredd": "^1.0.7",
+    "dredd": "https://github.com/contentful/dredd.git#private-header-use",
     "hercule": "^1.2.5"
   }
 }


### PR DESCRIPTION
There are two aspects to fixing this:

1. Hide the command executing dredd for the CMA as it contains the token
2. Use a patched dredd that doesn't log the Authorization header in case of errors