### PR TITLE
Remove json annotation in markdown codeblocks

### DIFF
--- a/apiary/_partials/cma/editing-interface.apib
+++ b/apiary/_partials/cma/editing-interface.apib
@@ -9,7 +9,7 @@ __Example__
 Let's consider the following Content Type which describes a typical blog post kind of data structure.
 It has a title, a body and a category that can be either "General", "iOS" or "Android".
 
-```json
+```
 {
   "fields": [
     { "id": "title", "name": "Title", "type": "Symbol" },
@@ -29,7 +29,7 @@ dropdown field (= `dropdown`).
 
 The Editing Interface would look like this:
 
-```json
+```
 {
   "controls": [
     { "fieldId": "title", "widgetId": "singleLine" },
@@ -77,7 +77,7 @@ __Settings__
 A control may have custom settings that are passed to the widget to change its behavior or presentation.
 
 The control entry for a field of type `Boolean`, for example, could look like this.
-```json
+```
 {
   "fieldId": "isFeatured",
   "widgetId": "boolean",
@@ -174,7 +174,3 @@ Note that when updating an existing Editing Interface, you always need to specif
 + Response 200 (application/vnd.contentful.management.v1+json)
 
     + Attributes (Complete Editing Interface)
-
-
-
-

--- a/apiary/_partials/collections-and-pagination.md
+++ b/apiary/_partials/collections-and-pagination.md
@@ -2,7 +2,7 @@
 
 Collections of resources are returned in a wrapper object that contains additional information useful for pagination over large result sets:
 
-```json
+```
 {
   "sys": { "type": "Array" },
   "skip": 0,

--- a/apiary/_partials/delivery-and-preview-resources.apib
+++ b/apiary/_partials/delivery-and-preview-resources.apib
@@ -6,7 +6,7 @@ Note that none of the `sys` fields are editable and only the `sys.id` field can 
 
 The `sys.id` property will be defined for every resource that is not a collection. For example, a `Space` resource will have a `sys.type` and `sys.id`:
 
-```json
+```
 {
   "sys": {
     "type": "Space",
@@ -245,7 +245,7 @@ Example: Include 2 levels of linked entries.
 
 + Response 200 (application/vnd.contentful.delivery.v1+json)
 
-  + Attributes (Empty Array)    
+  + Attributes (Empty Array)
 
 ## Omission of linked items [/spaces/{space_id}/entries?access_token={access_token}&include=0]
 
@@ -259,7 +259,7 @@ Even when not specified, the `include` parameter assumes the value of `1`. In th
 
 + Response 200 (application/vnd.contentful.delivery.v1+json)
 
-  + Attributes (Empty Array)    
+  + Attributes (Empty Array)
 
 ## Links to a specific item [/spaces/{space_id}/entries?access_token={access_token}&include={value}&content_type={content_type}&fields.{linking_field}.sys.id={target_entry_id}]
 
@@ -277,7 +277,7 @@ It might be useful to retrieve all items linked to a particular target Entry. To
 
 + Response 200 (application/vnd.contentful.delivery.v1+json)
 
-  + Attributes (Empty Array)    
+  + Attributes (Empty Array)
 
 # Group Search Parameters
 


### PR DESCRIPTION
Turns this 
<img width="799" alt="screen shot 2016-03-23 at 11 01 55" src="https://cloud.githubusercontent.com/assets/2362075/13981890/2869d8c6-f0e7-11e5-8e5b-59ec4b4724ef.png">
into this
<img width="803" alt="screen shot 2016-03-23 at 11 02 01" src="https://cloud.githubusercontent.com/assets/2362075/13981893/2bab14a0-f0e7-11e5-8428-c5e69ee35ccf.png">