### PR TITLE
Git ignore installed artifacts in Apiary

### DIFF
--- a/apiary/.gitignore
+++ b/apiary/.gitignore
@@ -2,6 +2,7 @@ cda.html
 cma.html
 *.out.apib
 
-apiary/node_modules
 node_modules
+.bundle
+vendor
 out


### PR DESCRIPTION
### Summary

Do not track ruby artifacts after running `make install`