### PR TITLE
Document locale's optional flag

### DIFF
--- a/apiary/cma.apib
+++ b/apiary/cma.apib
@@ -1556,6 +1556,7 @@ This endpoint allows the deletion of a Space Membership. It only affects the acc
 
 - name: `English (United States)` (string, required)
 - code: `en-US` (string, required)
+- optional: false (boolean) - Declare a locale as optional in localized fields
 
 ### Locale Complete
 
@@ -1563,6 +1564,7 @@ This endpoint allows the deletion of a Space Membership. It only affects the acc
 - contentDeliveryApi: `true` (boolean)
 - contentManagementApi: `true` (boolean)
 - `default`: `false` (boolean)
+- optional: `false` (boolean)
 - sys - System Attributes
   - type: `Locale` (string)
   - id: `34N35DoyUQAtaKwWTgZs34` (string)


### PR DESCRIPTION
### Summary

New changes introduced in the `Locale` API will allow customers to mark locales as optional and therefore omit content for them in `localized` fields.

**Important** Do not merge this PR before this changes have made their way to production.