### PR TITLE
Switch common resources for CPA to partial from CDA

### DIFF
--- a/apiary/cpa.apib
+++ b/apiary/cpa.apib
@@ -25,7 +25,7 @@ In the Preview API, there is a limit of 10 requests per second. The limit exists
 
 The rate limit is implemented through a standard mechanism of the HTTP protocol (returning response code 429).
 
-:[Common Resource Attributes](_partials/cma/resource-attributes.apib)
+:[Common Resource Attributes](_partials/cda/resource-attributes.apib)
 
 :[Shared Preview/Delivery Docs](_partials/delivery-and-preview-resources.apib tokentype:"A *preview* Content Delivery API key.")
 


### PR DESCRIPTION
Common resources in the CPA are actually equal to the CDA, not the CMA.

I hope the switch to the other partial works as expected as I can not test this myself.