### PR TITLE
Refactor hook file for dredd.

### DIFF
--- a/apiary/Makefile
+++ b/apiary/Makefile
@@ -77,11 +77,11 @@ test: check_cma_token prepare
 	$(DREDD) $(CPA_BLUEPRINT) $(CPA_HOST) --hookfiles=./test-hooks.js
 	$(DREDD) $(CDA_BLUEPRINT) $(CDA_HOST) --hookfiles=./test-hooks.js
 	@$(DREDD) $(CMA_BLUEPRINT) $(CMA_HOST) \
-		--hookfiles=./test-hooks.js \
+		--hookfiles=./test-hooks-cma.js \
 		-h "Authorization: Bearer $(CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN)" \
 		--private-header Authorization \
 		-m GET #-m PUT -m POST #-m DELETE
-	#$(DREDD) $(IMAGES_BLUEPRINT) $(IMAGES_HOST) --hookfiles=./test-hooks.js
+	#$(DREDD) $(IMAGES_BLUEPRINT) $(IMAGES_HOST)
 
 notify_slack:
 	@if [ "$(WEBHOOK_URL)" != "" -a "$(SLACK_CHANNEL)" != "" ]; then \

--- a/apiary/package.json
+++ b/apiary/package.json
@@ -6,7 +6,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "dredd": "https://github.com/contentful/dredd.git#private-header-use",
+    "dredd": "^1.0.7",
     "hercule": "^1.2.5"
   }
 }

--- a/apiary/test-hooks-cma.js
+++ b/apiary/test-hooks-cma.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var hooks = require('hooks');
+
+const DELAY = 1000/6.0;
+const SECRET_HEADERS = ['Authorization'].map(header => header.toLowerCase());
+
+/** We remove this data every 30 days making it incredibly hard to test.
+ *
+ * Read https://github.com/contentful/slash-developers/pull/279#issuecomment-222452488
+ * for more context
+ */
+hooks.before(
+  "Webhook calls > Webhook call details > Get the webhook call details",
+  function (transaction) {
+    transaction.skip = true;
+  });
+
+hooks.afterEach(function (transaction, done) {
+  // Some headers contain private data, we need to censor these
+  Object.keys(transaction.request.headers).forEach(function(key) {
+    if (SECRET_HEADERS.indexOf(key.toLowerCase()) > -1) {
+      transaction.request.headers[key] = "***HIDDEN SECRET DATA***";
+    }
+  });
+
+  setTimeout(done, DELAY);
+});

--- a/apiary/test-hooks.js
+++ b/apiary/test-hooks.js
@@ -3,20 +3,6 @@
 var hooks = require('hooks');
 var delay = 1000/6.0;
 
-hooks.beforeEach(function (t, done) {
-  let webhookCallPath = '/spaces/example/webhooks/hook123/calls/A123FOO';
-
-  if (t.fullPath === webhookCallPath) {
-    // Skip GET webhook call test.
-    //
-    // Read https://github.com/contentful/slash-developers/pull/279#issuecomment-222452488
-    // for more context
-    t.skip = true;
-  }
-
-  done();
-});
-
 hooks.afterEach(function (transaction, done) {
   setTimeout(done, delay);
 });


### PR DESCRIPTION
* Separate hook file for CMA
* No hook file for Images API
* Skip tests the way they are supposed to be tested
* Censor request headers through a hook. This allows switching away from our dredd fork.
* Use more ES6