### PR TITLE
Add rate limiting header docs

### DIFF
--- a/apiary/cda.apib
+++ b/apiary/cda.apib
@@ -21,9 +21,16 @@ As an authorization HTTP request-header field and as an URI query parameter name
 ## API rate limits
 
 Rate limits refer to the amount of requests per unit of time that can be done against our APIs.
-On the Content Delivery API there are no limits enforced on requests that hit the cache (i.e. a cache hit does not count towards rate limit and an unlimited amount of cache hits can be done). Nonetheless, there is still a rate limit of approximately 80 requests per seconds on the origin.
-
+On the Content Delivery API there are no limits enforced on requests that hit the cache (i.e. a cache hit does not count towards rate limit and an unlimited amount of cache hits can be done). Nonetheless, there is still a rate limit of 216000 requests per hour and 78 requests per seconds on the origin. Higher rate limits may apply for enterprise clients.
 The limit exists to prevent unlimited usage and ensure the consumption of resources that a single account can exercise is limited. The rate limit is implemented through a standard mechanism of the HTTP protocol (returning response code 429). Keep in mind that there are internal layers of caching close to the origin that again do not contribute to the rate limit.
+
+Contentful uses the `X-Contentful-RateLimit-Reset` header to inform a user when they can make their next request. This header is only sent for rate limited requests (429) due to caching mechanisms. If the header was sent for requests in the 2xx range it would be cached at the CDN layer and become inaccurate. Unlike requests that respond with the status code `200 OK`, a `429  Too Many Requests` response is not cached.
+
+Header                            | Status Code                                       | Description
+----------------------------------|---------------------------------------------------|----------------------------------------------------
+`X-Contentful-RateLimit-Reset`    | `429`. Returned only for rate limited requests.   | The number of seconds until the next request can be made.
+
+It's important to note that the `X-Contentful-RateLimit-Reset` header does _not_ return the time until the next full reset. Instead it tells you when the next request can be made. If a per second rate limit is enforced it will return `1` (time until the next second). If an hourly rate limit is enforced it will return the time until the next sliding window.
 
 :[Common Resource Attributes](_partials/cda/resource-attributes.apib apiname:"Content Delivery API")
 

--- a/apiary/cma.apib
+++ b/apiary/cma.apib
@@ -59,9 +59,21 @@ Contentful uses optimistic locking. When updating an existing resource its curre
 
 ## API rate limits
 
-In the Content Management API, there is a limit of 10 requests per second. The limit exists to prevent unlimited usage and ensure the consumption of resources that a single account can exercise is limited.
+The Content Management API enforces standard rate limits per hour and per second. The limits exist to prevent unlimited usage and ensure the consumption of resources that a single account can exercise is limited. Rate limits are set to 18000 requests per hour and 10 requests per second.
 
-The rate limit is implemented through a standard mechanism of the HTTP protocol (returning response code 429).
+The rate limits are implemented through a standard mechanism of the HTTP protocol (returning response code 429).
+
+Contentful uses HTTP headers to inform users how they're rate limited, what their rate limits are and when they can make their next request.
+
+Header                                    | Status Code   | Description
+------------------------------------------|---------------|----------------------------------------------------
+`X-Contentful-RateLimit-Hour-Limit`       | All requests. | The hourly rate limit.
+`X-Contentful-RateLimit-Hour-Remaining`   | All requests. | The number of requests remaining before the hourly rate limits are enforced.
+`X-Contentful-RateLimit-Second-Limit`     | All requests. | The per second rate limit.
+`X-Contentful-RateLimit-Second-Remaining` | All requests. | The number of requests remaining before the per second rate limits are enforced.
+`X-Contentful-RateLimit-Reset`            | All requests. | The number of seconds until the next request can be made.
+
+It's important to note that the `X-Contentful-RateLimit-Reset` header does _not_ return the time until the next full reset. Instead it tells you when the next request can be made. If a per second rate limit is enforced it will return `1` (time until the next second). If an hourly rate limit is enforced it will return the time until the next sliding window. If no limits are enforced it returns `0` because the next request can be made immediately.
 
 :[Common Resource Attribute](_partials/cma/resource-attributes.apib)
 

--- a/apiary/cpa.apib
+++ b/apiary/cpa.apib
@@ -21,9 +21,17 @@ The Preview API does not implement the Sync API, so applications that rely exclu
 
 ## API rate limits
 
-In the Preview API, there is a limit of 10 requests per second. The limit exists to prevent unlimited usage and ensure the consumption of resources that a single account can exercise is limited.
+The Content Preview API enforces standard rate limits per hour and per second. The limits exist to prevent unlimited usage and ensure the consumption of resources that a single account can exercise is limited. Rate limits are set to 7200 requests per hour and 10 requests per second.
 
-The rate limit is implemented through a standard mechanism of the HTTP protocol (returning response code 429).
+The rate limits are implemented through a standard mechanism of the HTTP protocol (returning response code 429).
+
+The Content Preview API uses the `X-Contentful-RateLimit-Reset` header to inform a user when they can make their next request. This header is only sent for rate limited requests (429). The rate limiting headers used in the Content Preview API are identical to those of the Content Delivery API for compatibility reasons.
+
+Header                            | Status Code                                       | Description
+----------------------------------|---------------------------------------------------|----------------------------------------------------
+`X-Contentful-RateLimit-Reset`    | `429`. Returned only for rate limited requests.   | The number of seconds until the next request can be made.
+
+It's important to note that the `X-Contentful-RateLimit-Reset` header does _not_ return the time until the next full reset. Instead it tells you when the next request can be made. If a per second rate limit is enforced it will return `1` (time until the next second). If an hourly rate limit is enforced it will return the time until the next sliding window.
 
 :[Common Resource Attributes](_partials/cda/resource-attributes.apib apiname:"Preview API")
 


### PR DESCRIPTION
## Deployment checklist
- [ ] The rate limiting headers need to be flagged to `on` in production by a change in chef.
- [x] Dani has been able to preview the docs locally which needs to be done to ensure they look OK.
- [x] We still need to decide on whether to send the `x-contentful-ratelimit-reset` header on all request or only 429s for the CMA and CPA.