### PR TITLE
Better links in the docs

### DIFF
--- a/docs/android/index.md
+++ b/docs/android/index.md
@@ -25,7 +25,7 @@ This SDK interacts with the Content Management API, and allows you to create, ed
 
 [View on GitHub](https://github.com/contentful/contentful-management.java)
 
-[API reference](http://contentful.github.io/contentful-management.java/)
+[API reference](https://contentful.github.io/contentful-management.java/)
 
 ## Tutorials
 

--- a/docs/android/tutorials/advanced-filtering-and-searching.md
+++ b/docs/android/tutorials/advanced-filtering-and-searching.md
@@ -133,7 +133,7 @@ CDAArray found = client.fetch(CDAEntry.class)
 ~~~
 
 This will return all entries with the `birthday` `less or equal then` *1980-01-01*. Other operators are available too,
-[see REST API doc](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/ranges)
+[see REST API doc](/developers/docs/references/content-delivery-api/#/reference/search-parameters/ranges)
 
 ## Inequality
 

--- a/docs/android/tutorials/advanced-types.md
+++ b/docs/android/tutorials/advanced-types.md
@@ -169,7 +169,7 @@ And this will be the result in only one asset (again using the `cfexampleapi` sp
 
 ## Content types
 
-In order to request all [content types](http://contentful.github.io/contentful.java/index.html?com/contentful/java/cda/CDAContentType.html),
+In order to request all [content types](https://contentful.github.io/contentful.java/index.html?com/contentful/java/cda/CDAContentType.html),
 you could use a call like this:
 
 ~~~ java
@@ -261,7 +261,7 @@ yielding
 ## Fetching all spaces
 
 For this example, you will need to [get a CMA API token](/developers/docs/references/authentication/#the-management-api)
-and create a [CMAClient](http://contentful.github.io/contentful-management.java/index.html?com/contentful/java/cma/CMAClient.html) using it:
+and create a [CMAClient](https://contentful.github.io/contentful-management.java/index.html?com/contentful/java/cma/CMAClient.html) using it:
 
 ~~~ java
 CMAClient cmaClient = new CMAClient.Builder()

--- a/docs/android/tutorials/advanced-types.md
+++ b/docs/android/tutorials/advanced-types.md
@@ -260,7 +260,7 @@ yielding
 
 ## Fetching all spaces
 
-For this example, you will need to [get a CMA API token](https://www.contentful.com/developers/docs/references/authentication/#the-management-api)
+For this example, you will need to [get a CMA API token](/developers/docs/references/authentication/#the-management-api)
 and create a [CMAClient](http://contentful.github.io/contentful-management.java/index.html?com/contentful/java/cma/CMAClient.html) using it:
 
 ~~~ java

--- a/docs/android/tutorials/offline-persistence-with-vault.md
+++ b/docs/android/tutorials/offline-persistence-with-vault.md
@@ -98,7 +98,7 @@ Now that you have the generator downloaded, you need to call it with the followi
 * `--folder <arg>` arg is the target folder to put the generated java sources into
 * `--package <arg>` use arg to specify the package name of the generated classes
 * `--space <arg>` use the space id given as arg (see above for details on how to get it)
-* `--token <arg>` please supply a management access token here. ([Find out more about your token](https://www.contentful.com/developers/docs/references/authentication/#the-management-api))
+* `--token <arg>` please supply a management access token here. ([Find out more about your token](/developers/docs/references/authentication/#the-management-api))
 
 
 The complete command will look like this (please provide your own space id and token, since we do not want to give them to the public):
@@ -238,5 +238,5 @@ If you have any questions or feedback, please feel free to drop us an email to [
 [config_xml]: https://github.com/contentful-labs/droidstory/blob/master/droidstory-android/app/src/main/res/values/config.xml#L3
 [droidstoryspace_java]: https://github.com/contentful-labs/droidstory/blob/master/droidstory-android/app/src/main/java/com/contentful/droidstory/data/vault/DroidStorySpace.java#L22
 [dsc]: https://github.com/contentful-labs/droidstory/tree/master/droidstory-spacecreator
-[cma_token]: https://www.contentful.com/developers/docs/references/authentication/#the-management-api
+[cma_token]: /developers/docs/references/authentication/#the-management-api
 

--- a/docs/concepts/locales.md
+++ b/docs/concepts/locales.md
@@ -2,7 +2,7 @@
 page: :docsLocales
 ---
 
-Locales are a feature of Contentful's [paid plans](https://www.contentful.com/pricing/). If you are working with content that needs to be available in multiple languages, locales let you define localizations of content and select a specific locale when querying the Content Delivery API.
+Locales are a feature of Contentful's [paid plans](/pricing/). If you are working with content that needs to be available in multiple languages, locales let you define localizations of content and select a specific locale when querying the Content Delivery API.
 
 Every Space has its own set of locales, and each locale is uniquely identified by its ISO code (e.g., `en-US` or `de-AT`). There's always one default locale defined when you create a space, shown by default in the Contentful web app and used for Content Delivery API queries that do not request a specific locale.
 
@@ -25,7 +25,7 @@ Choose a locale and its options:
 
 ### With the API
 
-If you are writing scripts or applications, use the [Content Management API](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/locales) to add a locale to a space use the following POST request with the name and ISO code contained within the body:
+If you are writing scripts or applications, use the [Content Management API](/developers/docs/references/content-management-api/#/reference/locales) to add a locale to a space use the following POST request with the name and ISO code contained within the body:
 
 ~~~bash
 curl -X POST
@@ -123,7 +123,7 @@ curl -X GET "https://cdn.contentful.com/spaces/<SPACE_ID>/entries/<ENTRY_ID>?acc
 
 ## Locales and the Sync API
 
-No matter which locale you specify, the [synchronization API](https://www.contentful.com/developers/docs/concepts/sync/) always includes all localized content, using the same structure as the wildcard locale option above:
+No matter which locale you specify, the [synchronization API](/developers/docs/concepts/sync/) always includes all localized content, using the same structure as the wildcard locale option above:
 
 ### URL of request
 

--- a/docs/concepts/sync.md
+++ b/docs/concepts/sync.md
@@ -56,6 +56,6 @@ Syncing entries or assets returns all available localizations instead of a singl
 ## Further information
 
 - Using the Sync API for [offline persistence on iOS](/developers/docs/ios/tutorials/offline-persistence-in-ios-sdk/).
-- Using synchronization with the [Content Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/synchronization).
+- Using synchronization with the [Content Delivery API](/developers/docs/references/content-delivery-api/#/reference/synchronization).
 - Using synchronization with the [PHP SDK](/developers/docs/php/tutorials/using-the-sync-api-with-php/).
 - Using synchronization with the [JavaScript SDK](/developers/docs/javascript/tutorials/using-the-sync-api-with-js/).

--- a/docs/ios/tutorials/offline-persistence-in-ios-sdk.md
+++ b/docs/ios/tutorials/offline-persistence-in-ios-sdk.md
@@ -147,7 +147,7 @@ The method will also ensure that the pre-seeded data is only used after the firs
 
 With this, our overview of synchronizing and keeping your content available for offline use is done. You should be able to provide a great experience for your users regardless of their data connection.
 
-[1]: https://www.contentful.com/blog/2014/09/03/content-management-api-sdk-ios/
+[1]: /blog/2014/09/03/content-management-api-sdk-ios/
 [2]: /developers/docs/concepts/sync/
 [3]: https://github.com/contentful/contentful.objc/tree/master/Examples
 [4]: http://cocoadocs.org/docsets/ContentfulDeliveryAPI/1.0.0/Classes/CDASyncedSpace.html
@@ -160,7 +160,7 @@ With this, our overview of synchronizing and keeping your content available for 
 [11]: https://github.com/contentful/contentful.objc
 [12]: http://cocoadocs.org/docsets/ContentfulDeliveryAPI/1.0.0/Protocols/CDASyncedSpaceDelegate.html
 [13]: http://nshipster.com/key-value-observing/
-[14]: https://www.contentful.com/developers/docs/content-delivery-api/objc/#sync
+[14]: /developers/docs/content-delivery-api/objc/#sync
 [15]: https://github.com/contentful/contentful-persistence.objc/blob/master/Code/CoreDataManager.h
 [16]: http://cocoadocs.org/docsets/ContentfulDeliveryAPI/1.0.0/Protocols/CDAPersistedAsset.html
 [17]: http://cocoadocs.org/docsets/ContentfulDeliveryAPI/1.0.0/Protocols/CDAPersistedEntry.html

--- a/docs/ios/tutorials/using-delivery-api-on-ios.md
+++ b/docs/ios/tutorials/using-delivery-api-on-ios.md
@@ -137,5 +137,5 @@ With this, our walk through the [coffee guide app][1] is done. You should have e
 [17]: https://github.com/contentful/contentful.objc
 [18]: https://static.contentful.com/downloads/iOS/ContentfulDeliveryAPI-1.9.2.zip
 [19]: /developers/docs/references/authentication/
-[20]: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters
-[21]: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/including-linked-entries
+[20]: /developers/docs/references/content-delivery-api/#/reference/search-parameters
+[21]: /developers/docs/references/content-delivery-api/#/reference/search-parameters/including-linked-entries

--- a/docs/ios/tutorials/using-delivery-api-with-swift.md
+++ b/docs/ios/tutorials/using-delivery-api-with-swift.md
@@ -128,13 +128,13 @@ With this, our walk through the [product catalogue app][1] is done. You should h
 [8]: http://cocoadocs.org/docsets/Contentful/0.2.1/Classes/Client.html#/s:FC10Contentful6Client12fetchEntriesFTGVs10DictionarySSPs9AnyObject___TGSqCSo20NSURLSessionDataTask_GC12Interstellar6SignalGVS_5ArrayVS_5Entry___
 [9]: http://cocoadocs.org/docsets/Contentful/0.2.1/Classes/Client.html#/s:FC10Contentful6Client12fetchEntriesFTGVs10DictionarySSPs9AnyObject__10completionFGO12Interstellar6ResultGVS_5ArrayVS_5Entry__T__GSqCSo20NSURLSessionDataTask_
 [10]: http://cocoadocs.org/docsets/Interstellar/1.4.0/Classes/Signal.html
-[11]: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters
+[11]: /developers/docs/references/content-delivery-api/#/reference/search-parameters
 [12]: https://github.com/contentful/ContentfulPlayground
-[13]: https://www.contentful.com/developers/docs/concepts/sync/
+[13]: developers/docs/concepts/sync/
 [14]: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CoreData/index.html
 [15]: http://cocoadocs.org/docsets/ContentfulPersistenceSwift/0.2.0/Protocols/PersistenceStore.html
 [16]: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CoreData/Concurrency.html
-[17]: https://www.contentful.com/developers/docs/ios/tutorials/using-contentful-xcode-plugin/
+[17]: /developers/docs/ios/tutorials/using-contentful-xcode-plugin/
 [18]: https://github.com/contentful/product-catalogue-swift/tree/master/Resources/Product%20Catalogue.xcdatamodeld
 [19]: https://github.com/path/FastImageCache
 [20]: https://github.com/contentful/product-catalogue-swift/blob/master/Code/DataSource.swift

--- a/docs/ios/tutorials/using-delivery-api-with-swift.md
+++ b/docs/ios/tutorials/using-delivery-api-with-swift.md
@@ -130,7 +130,7 @@ With this, our walk through the [product catalogue app][1] is done. You should h
 [10]: http://cocoadocs.org/docsets/Interstellar/1.4.0/Classes/Signal.html
 [11]: /developers/docs/references/content-delivery-api/#/reference/search-parameters
 [12]: https://github.com/contentful/ContentfulPlayground
-[13]: developers/docs/concepts/sync/
+[13]: /developers/docs/concepts/sync/
 [14]: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CoreData/index.html
 [15]: http://cocoadocs.org/docsets/ContentfulPersistenceSwift/0.2.0/Protocols/PersistenceStore.html
 [16]: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CoreData/Concurrency.html

--- a/docs/javascript/tutorials/create-expressjs-app-using-contentful.md
+++ b/docs/javascript/tutorials/create-expressjs-app-using-contentful.md
@@ -131,8 +131,8 @@ Do you like building static sites? Check how to build static sites using Content
 [14]: https://devcenter.heroku.com/articles/heroku-command-line#download-and-install
 [2]: https://nodejs.org
 [3]: https://github.com/contentful/contentful_express_tutorial
-[5]: https://www.contentful.com/sign-up/#starter
+[5]: /sign-up/#starter
 [6]: https://app.contentful.com
 [7]: /developers/docs/references/content-delivery-api/#/reference/search-parameters
 [8]: https://github.com/contentful/contentful.js
-[9]: https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/
+[9]: /developers/docs/javascript/tutorials/using-js-cda-sdk/

--- a/docs/javascript/tutorials/using-js-cda-sdk.md
+++ b/docs/javascript/tutorials/using-js-cda-sdk.md
@@ -18,7 +18,7 @@ In this tutorial, it is assumed you have understood the basic Contentful data mo
 
 To get started, for every request, clients [need to provide an API key](/developers/docs/references/authentication/), which is created per space and used to delimit audiences and content classes.
 
-You can create an access token using the [Contentful web app](https://be.contentful.com/login) or the [Content Management API](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/api-keys/create-an-api-key)
+You can create an access token using the [Contentful web app](https://be.contentful.com/login) or the [Content Management API](/developers/docs/references/content-management-api/#/reference/api-keys/create-an-api-key)
 
 ## Setting up the client
 
@@ -108,7 +108,7 @@ client.getEntry('O1ZiKekjgiE0Uu84oKqaY')
 
 The object received by the Promise callback represents the Entry `O1ZiKekjgiE0Uu84oKqaY` and contains two objects: `sys`, describing system properties of the entry, and `fields`, assigning specific values to fields (`title`,`body`,`image`) of its content type (`Blog Post`).
 
-For more details on the information contained on `sys` check out the [common resource attributes](https://www.contentful.com/developers/docs/references/content-delivery-api/#/introduction/common-resource-attributes) on the CDA API reference or the entities definitions on the [SDK reference](https://contentful.github.io/contentful.js/contentful/latest/Entities.html)
+For more details on the information contained on `sys` check out the [common resource attributes](/developers/docs/references/content-delivery-api/#/introduction/common-resource-attributes) on the CDA API reference or the entities definitions on the [SDK reference](https://contentful.github.io/contentful.js/contentful/latest/Entities.html)
 
 ## Retrieving all entries of a space
 
@@ -126,7 +126,7 @@ client.getEntries()
 })
 ~~~
 
-It's very similar to getting a single entry, except you'll get an array with all the retrieved entries, and some parameters relevant to [pagination](https://www.contentful.com/developers/docs/references/content-delivery-api/#/introduction/collection-resources-and-pagination).
+It's very similar to getting a single entry, except you'll get an array with all the retrieved entries, and some parameters relevant to [pagination](/developers/docs/references/content-delivery-api/#/introduction/collection-resources-and-pagination).
 
 By default you get 100 entries. If you'd like to retrieve more, you can skip the first 100. You can also retrieve more than 100 entries per request, up to 1000.
 ~~~javascript
@@ -140,7 +140,7 @@ client.getEntries({
 })
 ~~~
 
-Don't forget to also specify an ordering parameter to get more predictable results. You can read more about ordering parameters in the [search parameters API](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/order) reference.
+Don't forget to also specify an ordering parameter to get more predictable results. You can read more about ordering parameters in the [search parameters API](/developers/docs/references/content-delivery-api/#/reference/search-parameters/order) reference.
 
 ## Retrieving linked entries
 
@@ -174,7 +174,7 @@ client.getEntries({include: 0})
 
 You can also turn off link resolution when you initialize the SDK or with a `resolveLinks` property on every request.
 
-Check the [links reference page](https://www.contentful.com/developers/docs/concepts/links/) for more information on linked entries.
+Check the [links reference page](/developers/docs/concepts/links/) for more information on linked entries.
 
 ## Retrieving entries with search parameters
 
@@ -231,13 +231,13 @@ client.getEntries({
 
 There are many more search filters and operators you can use. You can perform the following kinds of searches:
 
-* [Equality/inequality](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/equality-operator) ([as well as in array fields](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/array-equalityinequality))
-* [Inclusion/exclusion](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/inclusion)
-* [Ranges](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/ranges)
-* [Full text search](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/full-text-search)
-* [Geo location searches](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/location-proximity-search)
+* [Equality/inequality](/developers/docs/references/content-delivery-api/#/reference/search-parameters/equality-operator) ([as well as in array fields](/developers/docs/references/content-delivery-api/#/reference/search-parameters/array-equalityinequality))
+* [Inclusion/exclusion](/developers/docs/references/content-delivery-api/#/reference/search-parameters/inclusion)
+* [Ranges](/developers/docs/references/content-delivery-api/#/reference/search-parameters/ranges)
+* [Full text search](/developers/docs/references/content-delivery-api/#/reference/search-parameters/full-text-search)
+* [Geo location searches](/developers/docs/references/content-delivery-api/#/reference/search-parameters/location-proximity-search)
 
-Check out the [search parameters API page](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters) for more information.
+Check out the [search parameters API page](/developers/docs/references/content-delivery-api/#/reference/search-parameters) for more information.
 
 ## Conclusion
 

--- a/docs/ruby/tutorials/automated-rebuild-and-deploy-with-circleci-and-webhooks.md
+++ b/docs/ruby/tutorials/automated-rebuild-and-deploy-with-circleci-and-webhooks.md
@@ -5,7 +5,7 @@ page: :docsRubyAutomatedRebuild
 If you're running our [Jekyll](https://github.com/contentful/jekyll-contentful-data-import) or [Middleman](https://github.com/contentful/contentful_middleman) integrations,
 you might be wondering how to automate your site building and publishing process.
 
-Here we'll discuss how you can automate this process using [Contentful Webhooks](https://www.contentful.com/developers/docs/concepts/webhooks/)
+Here we'll discuss how you can automate this process using [Contentful Webhooks](/developers/docs/concepts/webhooks/)
 and CircleCI API.
 
 > Everything we'll discuss here is for the case of using a public [GitHub](https://github.com) repository,

--- a/docs/ruby/tutorials/full-stack-getting-started.md
+++ b/docs/ruby/tutorials/full-stack-getting-started.md
@@ -149,7 +149,7 @@ If you want to set up new spaces via the command line we also provide [Contentfu
 
 [1]: https://github.com/contentful/contentful.rb
 [10]: https://github.com/contentful/contentful_rails_tutorial
-[12]: https://www.contentful.com/sign-up/#starter
+[12]: /sign-up/#starter
 [13]: https://app.contentful.com
 [14]: /developers/docs/ruby/tutorials/create-your-own-rails-app/
 [15]: /developers/docs/ruby/tutorials/getting-started-with-contentful-and-ruby/

--- a/docs/ruby/tutorials/getting-started-with-contentful-cma-and-ruby.md
+++ b/docs/ruby/tutorials/getting-started-with-contentful-cma-and-ruby.md
@@ -298,14 +298,14 @@ You can also check out how to get your spaces started with a single command usin
 * Image Credits: Picture "Unter den Linden", [Amira A][14] [License: Creative Commons 2.0][15]
 
 
-[0]: https://www.contentful.com/developers/docs/references/content-management-api/
-[1]: https://www.contentful.com/r/knowledgebase/content-modelling-basics/
-[2]: https://www.contentful.com/developers/docs/references/authentication/#getting-an-oauth-token
+[0]: /developers/docs/references/content-management-api/
+[1]: /r/knowledgebase/content-modelling-basics/
+[2]: /developers/docs/references/authentication/#getting-an-oauth-token
 [3]: https://github.com/contentful/contentful-management.rb/blob/01f5b2abfd1c00888197a6f79093b7ae0baee274/README.md
-[4]: https://www.contentful.com/developers/docs/references/content-management-api/#/reference/content-types
+[4]: /developers/docs/references/content-management-api/#/reference/content-types
 [5]: https://farm9.staticflickr.com/8144/6974761828_51c4fb1d54_z_d.jpg "Unter den Linden"
 [6]: https://github.com/contentful/contentful.rb
-[7]: https://www.contentful.com/developers/docs/ruby/tutorials/getting-started-with-contentful-and-ruby/
+[7]: /developers/docs/ruby/tutorials/getting-started-with-contentful-and-ruby/
 [8]: https://openbeerdb.com/
 [9]: https://github.com/contentful-labs/cma_import_script
 [10]: https://github.com/contentful/contentful-bootstrap.rb

--- a/docs/ruby/tutorials/using-contentful-bootstrap-for-keeping-up-with-your-spaces.md
+++ b/docs/ruby/tutorials/using-contentful-bootstrap-for-keeping-up-with-your-spaces.md
@@ -247,7 +247,7 @@ look in our [GitHub Repository][1] for the latest updates and releases. We're ge
 You should also check out how some of our demos use `contentful_bootstrap` for showcasing our
 static site generator integrations with [Middleman][2] and [Jekyll][3].
 
-[0]: https://www.contentful.com/developers/docs/references/content-delivery-api/
+[0]: /developers/docs/references/content-delivery-api/
 [1]: https://github.com/contentful/contentful-bootstrap.rb
 [2]: https://github.com/contentful/contentful_middleman_examples
 [3]: https://github.com/contentful/contentful_jekyll_examples

--- a/docs/tools/staticsitegenerators.md
+++ b/docs/tools/staticsitegenerators.md
@@ -40,7 +40,7 @@ We have more tools available to extend the functionality of Contentful. We have 
 
 ### Roots
 
-[Roots](http://roots.cx/) is a JavaScript based static site generator, and this plugin helps you manage content from Contentful.
+[Roots](https://roots.cx/) is a JavaScript based static site generator, and this plugin helps you manage content from Contentful.
 
 [View on GitHub](https://github.com/carrot/roots-contentful)
 

--- a/docs/tutorials/general/anatomy-cma-request.md
+++ b/docs/tutorials/general/anatomy-cma-request.md
@@ -227,7 +227,7 @@ Whereas the response yields the same `fields` array, `sys` is updated with new i
 ~~~
 
 ### Creating and publishing an entry
-To create an entry, we must specify a `X-Contentful-Content-Type` in the header and specify [locales](https://www.contentful.com/developers/docs/concepts/locales/) for its fields. In the following example, we will create a blog post entry:
+To create an entry, we must specify a `X-Contentful-Content-Type` in the header and specify [locales](/developers/docs/concepts/locales/) for its fields. In the following example, we will create a blog post entry:
 
 #### URL
 

--- a/docs/tutorials/general/scheduling-posts.md
+++ b/docs/tutorials/general/scheduling-posts.md
@@ -153,6 +153,6 @@ In this article we have:
 - Finally, you can find more static site generator integrations on our [tools][tools] page.
 
 [cf-mm-examples]: https://github.com/contentful/contentful_middleman_examples
-[filtering-reference]: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters
+[filtering-reference]: /developers/docs/references/content-delivery-api/#/reference/search-parameters
 [tools]: /developers/docs/tools/staticsitegenerators/
 


### PR DESCRIPTION
Two changes:
1. Use relative URLs for internal links.
2. Use HTTPS for external links when possible.

The first one makes working with staging and dev of the website a lot easier as it doesn't take you back to the main site.

The second is just me being anal.