### PR TITLE
Doc update. Strict query validation for skip, limit, and include

### DIFF
--- a/apiary/_partials/delivery-and-preview-resources.apib
+++ b/apiary/_partials/delivery-and-preview-resources.apib
@@ -200,7 +200,7 @@ Links are a powerful way to model relationships between content entries and asse
 
 When you have related content (e.g. entries with links to image assets) it's possible to include both search results and related data in a single request. Use the `include` parameter to do this, specifying the number of levels to resolve.
 
-The maximum number of inclusions is `10`. The default number, if the parameter is not specified, is `1`. If you want no inclusions at all, you should set it to `0`.
+The maximum number of inclusions is `10`. The API will throw `BadRequestError` for values higher than **10** or values other than an integer number. The default number, if the parameter is not specified, is `1`. If you want no inclusions at all, you should set it to `0`.
 
 This feature is only available in the Content Delivery and Preview APIs.
 
@@ -659,7 +659,7 @@ You can order items by specifying the `order` parameter along with attributes(`a
 
 You can specify the maximum number of results as a `limit` search parameter.
 
-**Note**: The maximum number of entries returned by the API is **1000** and it will ignore limits higher than **1000**. The default number of entries returned by the API is **100**.
+**Note**: The maximum number of entries returned by the API is **1000**. The API will throw `BadRequestError` for values higher than **1000** and values other than an integer number. The default number of entries returned by the API is **100**.
 
 + Parameters
     + space_id (required, string, `cfexampleapi`) ... Alphanumeric `id` of the space to retrieve.
@@ -676,7 +676,7 @@ This example limits results to 3 entries.
 
 ## Skip [/spaces/{space_id}/entries?access_token={access_token}&skip={value}]
 
-You can specify an offset with the `skip` search parameter.
+You can specify an offset with the `skip` search parameter. The API will throw `BadRequestError` for values less than **0** or values other than an integer number.
 
 By combining `skip` and `limit` you can paginate through results:
 

--- a/apiary/_partials/delivery-and-preview-resources.apib
+++ b/apiary/_partials/delivery-and-preview-resources.apib
@@ -200,7 +200,7 @@ Links are a powerful way to model relationships between content entries and asse
 
 When you have related content (e.g. entries with links to image assets) it's possible to include both search results and related data in a single request. Use the `include` parameter to do this, specifying the number of levels to resolve.
 
-The maximum number of inclusions is `10`. The API will throw `BadRequestError` for values higher than **10** or values other than an integer number. The default number, if the parameter is not specified, is `1`. If you want no inclusions at all, you should set it to `0`.
+The maximum number of inclusions is `10`. The API will throw a `BadRequestError` for values higher than **10** or values other than an integer. The default number, if the parameter is not specified, is `1`. If you want no inclusions at all, set it to `0`.
 
 This feature is only available in the Content Delivery and Preview APIs.
 
@@ -659,7 +659,7 @@ You can order items by specifying the `order` parameter along with attributes(`a
 
 You can specify the maximum number of results as a `limit` search parameter.
 
-**Note**: The maximum number of entries returned by the API is **1000**. The API will throw `BadRequestError` for values higher than **1000** and values other than an integer number. The default number of entries returned by the API is **100**.
+**Note**: The maximum number of entries returned by the API is **1000**. The API will throw a `BadRequestError` for values higher than **1000** and values other than an integer. The default number of entries returned by the API is **100**.
 
 + Parameters
     + space_id (required, string, `cfexampleapi`) ... Alphanumeric `id` of the space to retrieve.
@@ -676,7 +676,7 @@ This example limits results to 3 entries.
 
 ## Skip [/spaces/{space_id}/entries?access_token={access_token}&skip={value}]
 
-You can specify an offset with the `skip` search parameter. The API will throw `BadRequestError` for values less than **0** or values other than an integer number.
+You can specify an offset with the `skip` search parameter. The API will throw a `BadRequestError` for values less than **0** or values other than an integer.
 
 By combining `skip` and `limit` you can paginate through results:
 


### PR DESCRIPTION
We made a change in CDA that breaks the previous behaviors. The change is in production already. Here is the changelog: [https://www.contentful.com/developers/changelog/](https://www.contentful.com/developers/changelog/)