### PR TITLE
Make it explicit that the reference files should not be deleted

### DIFF
--- a/docs/references/content-delivery-api.md
+++ b/docs/references/content-delivery-api.md
@@ -2,3 +2,7 @@
 layout: api_reference
 page: :docsContentfulCda
 ---
+
+NOTE: DO NOT DELETE THIS FILE
+
+It's used in the marketing website to generate the sitemap file

--- a/docs/references/content-management-api.md
+++ b/docs/references/content-management-api.md
@@ -2,3 +2,7 @@
 layout: api_reference
 page: :docsContentfulCma
 ---
+
+NOTE: DO NOT DELETE THIS FILE
+
+It's used in the marketing website to generate the sitemap file

--- a/docs/references/content-preview-api.md
+++ b/docs/references/content-preview-api.md
@@ -2,3 +2,7 @@
 layout: api_reference
 page: :docsContentPreviewApi
 ---
+
+NOTE: DO NOT DELETE THIS FILE
+
+It's used in the marketing website to generate the sitemap file

--- a/docs/references/images-api.md
+++ b/docs/references/images-api.md
@@ -3,3 +3,6 @@ layout: api_reference
 page: :docsContentfulImagesApi
 ---
 
+NOTE: DO NOT DELETE THIS FILE
+
+It's used in the marketing website to generate the sitemap file


### PR DESCRIPTION
### Why this change

Because we need a warning sign to prevent people from removing these files from the repo while we don't find a way to include the files generated in the `doc-app` in the `marketing-website`'s `sitemap.xml` file. 